### PR TITLE
Implement dashboard scaffold

### DIFF
--- a/navigation/MainTabs.tsx
+++ b/navigation/MainTabs.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import DashboardScreen from '../src/screens/DashboardScreen';
+import BillsScreen from '../src/screens/BillsScreen';
+import RepresentativesScreen from '../src/screens/RepresentativesScreen';
+import BookmarksScreen from '../src/screens/BookmarksScreen';
+import SettingsScreen from '../src/screens/SettingsScreen';
+
+export type TabParamList = {
+  Dashboard: undefined;
+  Bills: undefined;
+  Representatives: undefined;
+  Bookmarks: undefined;
+  Settings: undefined;
+};
+
+const Tab = createBottomTabNavigator<TabParamList>();
+
+export default function MainTabs() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Dashboard" component={DashboardScreen} />
+      <Tab.Screen name="Bills" component={BillsScreen} />
+      <Tab.Screen name="Representatives" component={RepresentativesScreen} />
+      <Tab.Screen name="Bookmarks" component={BookmarksScreen} />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
+    </Tab.Navigator>
+  );
+}

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -3,10 +3,12 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Home from '../screens/Home';
 import Login from '../screens/Login';
+import MainTabs from './MainTabs';
 
 export type RootStackParamList = {
   Home: undefined;
   Login: undefined;
+  Main: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -17,6 +19,11 @@ export default function Navigation() {
       <Stack.Navigator initialRouteName="Home">
         <Stack.Screen name="Home" component={Home} />
         <Stack.Screen name="Login" component={Login} />
+        <Stack.Screen
+          name="Main"
+          component={MainTabs}
+          options={{ headerShown: false }}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/webpack-config": "^19.0.0",
+        "@react-navigation/bottom-tabs": "^6.6.1",
         "@react-navigation/native": "^6.1.6",
         "@react-navigation/native-stack": "^6.9.12",
+        "axios": "^1.9.0",
         "expo": "~49.0.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -4838,6 +4840,24 @@
         "react-native": "*"
       }
     },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-6.6.1.tgz",
+      "integrity": "sha512-9oD4cypEBjPuaMiu9tevWGiQ4w/d6l3HNhcJ1IjXZ24xvYDSs0mqjUcdt8SWUolCvRrYc/DmNBLlT83bk0bHTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.31",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
+      }
+    },
     "node_modules/@react-navigation/core": {
       "version": "6.4.17",
       "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-6.4.17.tgz",
@@ -6222,6 +6242,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -7323,6 +7369,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7340,6 +7399,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -15819,6 +15888,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -17216,6 +17291,21 @@
       "engines": {
         "node": ">= 5.10.0"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -11,27 +11,29 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
+    "@expo/webpack-config": "^19.0.0",
+    "@react-navigation/bottom-tabs": "^6.6.1",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "axios": "^1.9.0",
     "expo": "~49.0.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.72.4",
-    "react-native-web": "~0.19.6",
-    "@react-navigation/native": "^6.1.6",
-    "@react-navigation/native-stack": "^6.9.12",
-    "react-native-screens": "~3.22.0",
     "react-native-safe-area-context": "4.8.2",
-    "@expo/webpack-config": "^19.0.0"
+    "react-native-screens": "~3.22.0",
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@types/react": "18.2.14",
     "@types/react-native": "0.72.6",
-    "typescript": "5.2.2",
+    "@typescript-eslint/eslint-plugin": "6.13.1",
+    "@typescript-eslint/parser": "6.13.1",
     "eslint": "8.49.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-react": "7.33.2",
     "eslint-plugin-react-hooks": "4.6.0",
-    "@typescript-eslint/eslint-plugin": "6.13.1",
-    "@typescript-eslint/parser": "6.13.1",
-    "prettier": "3.1.0"
+    "prettier": "3.1.0",
+    "typescript": "5.2.2"
   }
 }

--- a/screens/Login.tsx
+++ b/screens/Login.tsx
@@ -9,7 +9,7 @@ export default function Login({ navigation }: Props) {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Login Screen</Text>
-      <Button title="Go to Home" onPress={() => navigation.navigate('Home')} />
+      <Button title="Login" onPress={() => navigation.navigate('Main')} />
     </View>
   );
 }

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -1,0 +1,24 @@
+// Placeholder implementations return dummy data until backend is available
+
+export const fetchUserInfo = async (_token: string) => {
+  // TODO: replace with real API call
+  void _token;
+  return Promise.resolve({
+    data: {
+      id: 1,
+      email: 'demo@example.com',
+      name: 'Demo User',
+    },
+  });
+};
+
+export const fetchUserNotifications = async (_token: string) => {
+  // TODO: replace with real API call
+  void _token;
+  return Promise.resolve({
+    data: [
+      { id: '1', message: 'Bill HR123 was updated.' },
+      { id: '2', message: 'Rep Jane Doe voted on SB456.' },
+    ],
+  });
+};

--- a/src/components/Dashboard/RecentUpdatesList.tsx
+++ b/src/components/Dashboard/RecentUpdatesList.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
+
+export interface UpdateItem {
+  id: string;
+  message: string;
+}
+
+interface Props {
+  updates: UpdateItem[];
+}
+
+export default function RecentUpdatesList({ updates }: Props) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Recent Updates</Text>
+      <FlatList
+        data={updates}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <Text style={styles.item}>{item.message}</Text>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#fff',
+    padding: 16,
+    borderRadius: 8,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  item: {
+    paddingVertical: 4,
+  },
+});

--- a/src/components/Dashboard/WelcomeCard.tsx
+++ b/src/components/Dashboard/WelcomeCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+interface Props {
+  name: string;
+}
+
+export default function WelcomeCard({ name }: Props) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Welcome, {name}!</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  text: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+});

--- a/src/screens/BillsScreen.tsx
+++ b/src/screens/BillsScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function BillsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Bills Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/screens/BookmarksScreen.tsx
+++ b/src/screens/BookmarksScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function BookmarksScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Bookmarks Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import WelcomeCard from '../components/Dashboard/WelcomeCard';
+import RecentUpdatesList, { UpdateItem } from '../components/Dashboard/RecentUpdatesList';
+import { fetchUserInfo, fetchUserNotifications } from '../api/userApi';
+
+export default function DashboardScreen() {
+  const [name, setName] = useState('');
+  const [updates, setUpdates] = useState<UpdateItem[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const userRes = await fetchUserInfo('fake-token');
+      setName(userRes.data.name || userRes.data.email);
+      const updatesRes = await fetchUserNotifications('fake-token');
+      setUpdates(updatesRes.data);
+    };
+    load();
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <WelcomeCard name={name} />
+      <RecentUpdatesList updates={updates} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#f0f0f0',
+  },
+});

--- a/src/screens/RepresentativesScreen.tsx
+++ b/src/screens/RepresentativesScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function RepresentativesScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Representatives Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SettingsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Settings Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- add bottom tab navigation
- add dashboard screen and related components
- scaffold API helper returning dummy data
- wire login to new main tab navigator
- install axios and tabs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684079dea2508323bf8e30bd701e640a